### PR TITLE
Switch to kTISNotifySelectedKeyboardInputSourceChanged delegate

### DIFF
--- a/input-sources/AppDelegate.swift
+++ b/input-sources/AppDelegate.swift
@@ -1,6 +1,7 @@
 import Cocoa
 import Defaults
 import KeyboardShortcuts
+import Carbon
 
 let shortNames = (try? String(contentsOf: Bundle.main.url(forResource: "codes", withExtension: "plist")!).propertyList() as? [String: String])
 
@@ -31,7 +32,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         Defaults.observe(.showMenuBG, options: [.initial], handler: { _ in self.render() })
             .tieToLifetime(of: self)
-        NotificationCenter.default.addObserver(self, selector: #selector(render), name: NSTextInputContext.keyboardSelectionDidChangeNotification, object: nil)
+        DistributedNotificationCenter.default().addObserver(
+            self,
+            selector: #selector(render),
+            name: kTISNotifySelectedKeyboardInputSourceChanged as NSNotification.Name?,
+            object: nil,
+            suspensionBehavior: .deliverImmediately
+        )
 
         KeyboardShortcuts.onKeyUp(for: .nextInputSource, action: selectNextLayout)
 


### PR DESCRIPTION
On my system (Sonoma 14.5) current language change detection using  NotificationCenter + keyboardSelectionDidChangeNotification is finicky at best. It gets called reliably, but when reading TISCopyCurrentKeyboardLayoutInputSource() from inside render(), it returns old stale value half of the times, with both changes caused by keyboard shortcut or by switching applications with different input languages.

This method using DistributedNotificationCenter + kTISNotifySelectedKeyboardInputSourceChanged is copied from ShowyEdge and from my testing is 100% reliable.